### PR TITLE
Fix cfg checks for iOS and other BSDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,16 +20,11 @@ fn get_num_cpus() -> usize {
 }
 
 #[cfg(
-    all(
-        any(
-            target_os = "macos",
-            target_os = "ios",
-            target_os = "freebsd",
-            target_os = "dragonfly",
-            target_os = "bitrig",
-            target_os = "openbsd"
-        ),
-        not(unix)
+    any(
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "bitrig",
+        target_os = "openbsd"
     )
 )]
 fn get_num_cpus() -> usize {
@@ -77,7 +72,12 @@ fn get_num_cpus() -> usize {
     }
 }
 
-#[cfg(target_os="macos")]
+#[cfg(
+    any(
+        target_os = "macos",
+        target_os = "ios"
+    )
+)]
 fn get_num_cpus() -> usize {
     //to-do: replace with libc::_SC_NPROCESSORS_ONLN once available
     unsafe {


### PR DESCRIPTION
Without this change, num_cpus doesn't build when cross-compiling for iOS. (iOS provides the same sysconf interface as macos.)

I can't test the other BSDs affected by this change, but I'm pretty sure this is correct. The `not(unix)` that was present excluded all of those BSDs, as evidenced by `target_os = macos` showing up on two different implementations but not causing problems.