### PR TITLE
Add Android version of get_num_cpus

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,15 @@ fn get_num_cpus() -> usize {
         libc::sysconf(84) as usize
     }
 }
+
+#[cfg(target_os= "android")]
+fn get_num_cpus() -> usize {
+    //to-do: replace with libc::_SC_NPROCESSORS_ONLN once available
+    unsafe {
+        libc::sysconf(97) as usize
+    }
+}
+
 #[cfg(target_os = "nacl")]
 fn get_num_cpus() -> usize {
     //to-do: replace with libc::_SC_NPROCESSORS_ONLN once available


### PR DESCRIPTION
r? @seanmonstar 

```
[larsberg@lbergstrom android-ndk-r9c]$ grep -r _SC_NPROCESSORS_ONLN *
platforms/android-18/arch-arm/usr/include/sys/sysconf.h:#define _SC_NPROCESSORS_ONLN            0x0061
platforms/android-18/arch-mips/usr/include/sys/sysconf.h:#define _SC_NPROCESSORS_ONLN            0x0061
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/seanmonstar/num_cpus/9)
<!-- Reviewable:end -->
