### PR TITLE
get_physical() for Mac OS X

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,14 +99,15 @@ pub fn get_physical() -> usize {
 
 #[cfg(target_os="macos")]
 fn get_physical_num_cpus() -> usize {
-    use std::ffi::CString;
     use libc::size_t;
     use libc::sysctlbyname;
     use std::ptr;
     use libc::c_void;
 
+    static HW_PHYSICALCPU: &'static [i8] = &[104i8, 119, 46, 112, 104, 121, 115, 105, 99, 97, 108, 99, 112, 117, 0];
+
     unsafe {
-        let name = CString::new("hw.physicalcpu").unwrap().as_ptr();
+        let name = HW_PHYSICALCPU.as_ptr();
         let mut count = 0;
         let mut count_len = ::std::mem::size_of::<size_t>();
         sysctlbyname(name, &mut count as *mut _ as *mut c_void, &mut count_len as *mut _, ptr::null_mut(), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,34 @@ fn get_num_cpus() -> usize {
     }
 }
 
+/// Returns the number of physical CPUs of the current machine.
+#[inline]
+pub fn get_physical() -> usize {
+    get_physical_num_cpus()
+}
+
+#[cfg(target_os="macos")]
+fn get_physical_num_cpus() -> usize {
+    use std::ffi::CString;
+    use libc::size_t;
+    use libc::sysctlbyname;
+    use std::ptr;
+    use libc::c_void;
+
+    unsafe {
+        let name = CString::new("hw.physicalcpu").unwrap().as_ptr();
+        let mut count = 0;
+        let mut count_len = ::std::mem::size_of::<size_t>();
+        sysctlbyname(name, &mut count as *mut _ as *mut c_void, &mut count_len as *mut _, ptr::null_mut(), 0);
+        count as usize
+    }
+}
+
+#[cfg(not(target_os="macos"))]
+fn get_physical_num_cpus() -> usize {
+    panic!("Platform not supported, yet!")
+}
+
 #[test]
 fn lower_bound() {
     assert!(get() > 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ fn get_num_cpus() -> usize {
 }
 
 /// Returns the number of physical CPUs of the current machine.
+/// Currently only Mac OSX is supported.
 #[inline]
 pub fn get_physical() -> usize {
     get_physical_num_cpus()
@@ -111,11 +112,6 @@ fn get_physical_num_cpus() -> usize {
         sysctlbyname(name, &mut count as *mut _ as *mut c_void, &mut count_len as *mut _, ptr::null_mut(), 0);
         count as usize
     }
-}
-
-#[cfg(not(target_os="macos"))]
-fn get_physical_num_cpus() -> usize {
-    panic!("Platform not supported, yet!")
 }
 
 #[test]


### PR DESCRIPTION
The start of an implementation for the number of physical cores (#5). Not sure about the naming though and if this is something that should even be merged in this state (i.e. only supporting OSX).