### PR TITLE
Sync some definitions and boost compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,3 @@ repository = "https://github.com/seanmonstar/num_cpus"
 
 [dependencies]
 libc = "0.2"
-winapi = "0.2"
-kernel32-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,20 +89,13 @@ fn get_num_cpus() -> usize {
         target_os = "linux",
         target_os = "nacl",
         target_os = "macos",
-        target_os = "ios"
+        target_os = "ios",
+        target_os = "android",
     )
 )]
 fn get_num_cpus() -> usize {
     unsafe {
         libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as usize
-    }
-}
-
-#[cfg(target_os= "android")]
-fn get_num_cpus() -> usize {
-    //to-do: replace with libc::_SC_NPROCESSORS_ONLN once available
-    unsafe {
-        libc::sysconf(97) as usize
     }
 }
 


### PR DESCRIPTION
This has a few changes:

* All BSD definitions are synced with libtest, relying on liblibc-defined constants
* The Android definition also now relies on a liblibc-defined constant
* The winapi/kernel32 deps were dropped as they take 30s to compile where this library takes 0.1s