### PR TITLE
Add dummy implementation for emscripten targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,10 @@ fn get_num_cpus() -> usize {
         libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as usize
     }
 }
+#[cfg(target_os = "emscripten")]
+fn get_num_cpus() -> usize {
+    1
+}
 
 #[test]
 fn lower_bound() {


### PR DESCRIPTION
Fixes #26 

I'm not sure if this is the best solution. JavaScript doesn't support threads natively, emscripten has only experimental support for threading via some kind of Firefox nightly extension. So AFAIK practically, threads are unusable right now.

So I see three possibilities:

1. Do what this PR does right now (return 1 CPU)
2. Panic in `get_num_cpus()` to signal that the operation doesn't make any sense in the current environment 
3. Don't do anything, because compiling this crate with said target doesn't make any sense

What do you think?