### PR TITLE
Add support for Fuchsia.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,7 @@ fn get_num_cpus() -> usize {
         target_os = "ios",
         target_os = "android",
         target_os = "solaris",
+        target_os = "fuchsia",
     )
 )]
 fn get_num_cpus() -> usize {


### PR DESCRIPTION
As some background, [Fuchsia](https://en.wikipedia.org/wiki/Google_Fuchsia) is a new operating system [under development](https://github.com/fuchsia-mirror) by Google. It is based on a new microkernel called [Magenta](https://github.com/fuchsia-mirror/magenta).

Used for `nproc` in coreutils.

ref https://github.com/uutils/coreutils/issues/999

cc @raphlinus