### PR TITLE
Add initial Haiku support.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ fn get_num_cpus() -> usize {
         libc::sysconf(libc::_SC_NPROCESSORS_ONLN) as usize
     }
 }
-#[cfg(any(target_os = "emscripten", target_os = "redox"))]
+#[cfg(any(target_os = "emscripten", target_os = "redox", target_os = "haiku"))]
 fn get_num_cpus() -> usize {
     1
 }


### PR DESCRIPTION
A proper implementation is missing, as support for Haiku in rust's
libc is incomplete.