### PR TITLE
Use PROCESSORS_CONF instead of PROCESSORS_ONLN to fix ARM bug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ fn get_num_cpus() -> usize {
     target_os = "fuchsia")
 )]
 fn get_num_cpus() -> usize {
-    let cpus = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+    let cpus = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_CONF) };
     if cpus < 1 {
         1
     } else {


### PR DESCRIPTION
This pull request aims to close #34, which could result in an inexact number of CPUs on Android / ARM targets. 