### PR TITLE
Add OS X environment for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rust:
   - beta
   - nightly
 
+os:
+  - linux
+  - osx
+
 sudo: false
 
 cache:


### PR DESCRIPTION
This commit modifies the Travis CI settings to also build and test the crate on Mac OS X targets.
Improves #47, although more improvemenets are required before the issue is closed (e.g. build the crate for Android).

The documentation for multi-OS builds is at https://docs.travis-ci.com/user/multi-os/