### PR TITLE
Add more targets to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
         apt:
           packages:
             - gcc-multilib
+    # 64-bit stable.
+    - env: TARGET=x86_64-unknown-linux-gnu RUN=1 NO_ADD=1
+      rust: stable
+    # 64-bit beta.
+    - env: TARGET=x86_64-unknown-linux-gnu RUN=1 NO_ADD=1
+      rust: beta
     # 64-bit nightly.
     - env: TARGET=x86_64-unknown-linux-gnu RUN=1 NO_ADD=1
       rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ matrix:
     - os: osx
       osx_image: xcode9
       env: TARGET=x86_64-apple-ios
+    # BSD derivatives.
+    - env: TARGET=x86_64-unknown-freebsd
+    - env: TARGET=x86_64-unknown-openbsd
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: rust
-rust:
-  - stable
-  - beta
-  - nightly
 
 dist: trusty
 sudo: false
 
 cache: cargo
 
-rustup-install:
+# Override the default Travis script.
+install:
+  - if [ -z "$TRAVIS_RUST_VERSION" ]; then TRAVIS_RUST_VERSION="stable"; fi
   - curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-host=$TARGET --default-toolchain=$TRAVIS_RUST_VERSION -y
 
 script:
@@ -28,6 +26,10 @@ matrix:
             - gcc-multilib
     # 64-bit works as-is.
     - env: TARGET=x86_64-unknown-linux-gnu RUN=1
+      rust:
+      - stable
+      - beta
+      - nightly
     # Mac OS X
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ cache: cargo
 
 install:
   # If no TARGET is set, we are running on Linux, and we are building for stable/beta/nightly Rust.
-  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux-gnu" && RUN="1"; else rustup target add "$TARGET"; fi
+  - if [ -z "$TARGET" ]; then
+      TARGET="x86_64-unknown-linux-gnu" && RUN="1";
+    else
+      rustup target add "$TARGET";
+    fi
 
 script:
   - cargo build --verbose --target "$TARGET"
   # Only run the targets if we are on the same OS.
-  - [ "$RUN" == "1" ] && cargo test --verbose --target "$TARGET"
-
+  - $RUN && cargo test --verbose --target "$TARGET"
 matrix:
   include:
     # Mac OS X

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
   - beta
   - nightly
 
+dist: trusty
 sudo: false
 
 cache: cargo

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache: cargo
 
 install:
   # If no TARGET is set, we are running on Linux, and we are building for stable/beta/nightly Rust.
-  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux-gnu" && RUN="1"; else rustup target add "$TARGET" fi
+  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux-gnu" && RUN="1"; else rustup target add "$TARGET"; fi
 
 script:
   - cargo build --verbose --target "$TARGET"
@@ -24,7 +24,7 @@ matrix:
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1
     - os: osx
-      env: TARGET=x86_64-apple-darwin RUN=1
+      # No env variables because we are building and running for this architecture.
     # Android
     # - for x86
     - env: TARGET=i686-linux-android

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,18 @@ sudo: false
 cache: cargo
 
 install:
-  - echo "$TARGET"
+  # If no TARGET is set, we are running on Linux, and we are building for stable/beta/nightly Rust.
+  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux"; fi
   - rustup target add "$TARGET"
 
 script:
   - cargo build --verbose --target "$TARGET"
   # Only run the targets if we are on the same OS.
-  - if [ -z "$RUN" ]; then cargo test --verbose --target "$TARGET"; fi
+  - if [ "$RUN" == "1" ]; then cargo test --verbose --target "$TARGET"; fi
 
 matrix:
   include:
-    # Linux (32-bit, 64-bit is already covered by the `rust ...` setting above)
+    # Linux (32-bit, 64-bit is already covered above)
     - env: TARGET=i686-unknown-linux-gnu RUN=1
     # Mac OS X
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ cache: cargo
 
 install:
   # If no TARGET is set, we are running on Linux, and we are building for stable/beta/nightly Rust.
-  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux-gnu"; fi
-  - rustup target add "$TARGET"
+  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux-gnu" && RUN="1"; else rustup target add "$TARGET" fi
 
 script:
   - cargo build --verbose --target "$TARGET"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,28 @@ sudo: false
 cache: cargo
 
 install:
-  # If no TARGET is set, we are running on Linux, and we are building for stable/beta/nightly Rust.
-  - if [ -z "$TARGET" ]; then
-      TARGET="x86_64-unknown-linux-gnu" && RUN="1";
-    else
-      rustup target add "$TARGET";
-    fi
+  - curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-host=$TARGET --default-toolchain=$TRAVIS_RUST_VERSION -y
 
 script:
-  - cargo build --verbose --target "$TARGET"
+  - cargo build --verbose
   # Only run the targets if we are on the same OS.
-  - $RUN && cargo test --verbose --target "$TARGET"
+  - if [ "$RUN" == "1" ]; then cargo test --verbose fi
 matrix:
   include:
+    # Linux
+    # 32-bit requires multilib.
+    - env: TARGET=i686-unknown-linux-gnu RUN=1
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+    # 64-bit works as-is.
+    - env: TARGET=x86_64-unknown-linux-gnu RUN=1
     # Mac OS X
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1
     - os: osx
-      # No env variables because we are building and running for this architecture.
+      env: TARGET=x86_64-apple-darwin RUN=1
     # Android
     # - for x86
     - env: TARGET=i686-linux-android
@@ -44,7 +48,6 @@ matrix:
       env: TARGET=x86_64-apple-ios
     # BSD derivatives.
     - env: TARGET=x86_64-unknown-freebsd
-    - env: TARGET=x86_64-unknown-openbsd
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-
+rust: stable
 dist: trusty
 sudo: false
 
@@ -7,13 +7,12 @@ cache: cargo
 
 # Override the default Travis script.
 install:
-  - if [ -z "$TRAVIS_RUST_VERSION" ]; then TRAVIS_RUST_VERSION="stable"; fi
-  - curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-host=$TARGET --default-toolchain=$TRAVIS_RUST_VERSION -y
+  - if [ -z "$NO_ADD" ]; then rustup target add "$TARGET"; fi
 
 script:
-  - cargo build --verbose
+  - cargo build --verbose --target "$TARGET"
   # Only run the targets if we are on the same OS.
-  - if [ "$RUN" == "1" ]; then cargo test --verbose; fi
+  - if [ "$RUN" == "1" ]; then cargo test --verbose --target "$TARGET"; fi
 
 matrix:
   include:
@@ -24,17 +23,15 @@ matrix:
         apt:
           packages:
             - gcc-multilib
-    # 64-bit works as-is.
-    - env: TARGET=x86_64-unknown-linux-gnu RUN=1
+    # 64-bit nightly.
+    - env: TARGET=x86_64-unknown-linux-gnu RUN=1 NO_ADD=1
       rust:
-      - stable
-      - beta
       - nightly
     # Mac OS X
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1
     - os: osx
-      env: TARGET=x86_64-apple-darwin RUN=1
+      env: TARGET=x86_64-apple-darwin RUN=1 NO_ADD=1
     # Android
     # - for x86
     - env: TARGET=i686-linux-android

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 script:
   - cargo build --verbose --target "$TARGET"
   # Only run the targets if we are on the same OS.
-  - if [ "$RUN" == "1" ]; then cargo test --verbose --target "$TARGET"; fi
+  - [ "$RUN" == "1" ] && cargo test --verbose --target "$TARGET"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ sudo: false
 
 cache: cargo
 
-install:
+rustup-install:
   - curl -sSf https://build.travis-ci.org/files/rustup-init.sh | sh -s -- --default-host=$TARGET --default-toolchain=$TRAVIS_RUST_VERSION -y
 
 script:
   - cargo build --verbose
   # Only run the targets if we are on the same OS.
-  - if [ "$RUN" == "1" ]; then cargo test --verbose fi
+  - if [ "$RUN" == "1" ]; then cargo test --verbose; fi
+
 matrix:
   include:
     # Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 
 cache: cargo
 
-# Override the default Travis script.
 install:
   - if [ -z "$NO_ADD" ]; then rustup target add "$TARGET"; fi
 
@@ -25,8 +24,7 @@ matrix:
             - gcc-multilib
     # 64-bit nightly.
     - env: TARGET=x86_64-unknown-linux-gnu RUN=1 NO_ADD=1
-      rust:
-      - nightly
+      rust: nightly
     # Mac OS X
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,12 @@ install:
 script:
   - cargo build --verbose --target "$TARGET"
   # Only run the targets if we are on the same OS.
-  - if [ -z "$RUN" ] cargo test --verbose --target "$TARGET"; fi
+  - if [ -z "$RUN" ]; then cargo test --verbose --target "$TARGET"; fi
 
 matrix:
   include:
-    # Linux
+    # Linux (32-bit, 64-bit is already covered by the `rust ...` setting above)
     - env: TARGET=i686-unknown-linux-gnu RUN=1
-    - env: TARGET=x86_64-unknown-linux-gnu RUN=1
     # Mac OS X
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,42 @@ rust:
   - beta
   - nightly
 
-os:
-  - linux
-  - osx
-
 sudo: false
 
-cache:
-  apt: true
-  directories:
-    - target/debug/deps
-    - target/debug/build
+cache: cargo
+
+install:
+  - rustup target add $TARGET
 
 script:
-  - cargo build --verbose
-  - cargo test --verbose
+  - cargo build --verbose --target $TARGET
+  # Only run the targets if we are on the same OS.
+  - if [ -z "$RUN" ] cargo test --verbose --target $TARGET; fi
+
+matrix:
+  include:
+    # Linux
+    - env: TARGET=i686-unknown-linux-gnu RUN=1
+    - env: TARGET=x86_64-unknown-linux-gnu RUN=1
+    # Mac OS X
+    - os: osx
+      env: TARGET=i686-apple-darwin RUN=1
+    - os: osx
+      env: TARGET=x86_64-apple-darwin RUN=1
+    # Android
+    # - for x86
+    - env: TARGET=i686-linux-android
+    - env: TARGET=x86_64-linux-android
+    # - for ARM
+    - env: TARGET=arm-linux-androideabi
+    - env: TARGET=aarch64-linux-android
+    # IOS
+    - os: osx
+      osx_image: xcode9
+      env: TARGET=i386-apple-ios
+    - os: osx
+      osx_image: xcode9
+      env: TARGET=x86_64-apple-ios
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ sudo: false
 cache: cargo
 
 install:
-  - rustup target add $TARGET
+  - echo "$TARGET"
+  - rustup target add "$TARGET"
 
 script:
   - cargo build --verbose --target $TARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache: cargo
 
 install:
   # If no TARGET is set, we are running on Linux, and we are building for stable/beta/nightly Rust.
-  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux"; fi
+  - if [ -z "$TARGET" ]; then TARGET="x86_64-unknown-linux-gnu"; fi
   - rustup target add "$TARGET"
 
 script:
@@ -21,8 +21,6 @@ script:
 
 matrix:
   include:
-    # Linux (32-bit, 64-bit is already covered above)
-    - env: TARGET=i686-unknown-linux-gnu RUN=1
     # Mac OS X
     - os: osx
       env: TARGET=i686-apple-darwin RUN=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ install:
   - rustup target add "$TARGET"
 
 script:
-  - cargo build --verbose --target $TARGET
+  - cargo build --verbose --target "$TARGET"
   # Only run the targets if we are on the same OS.
-  - if [ -z "$RUN" ] cargo test --verbose --target $TARGET; fi
+  - if [ -z "$RUN" ] cargo test --verbose --target "$TARGET"; fi
 
 matrix:
   include:


### PR DESCRIPTION
This commit tries to improve #47. It adds support for building the following targets:
- Linux
- Mac OS X
- Android (x86 and ARM)
- iOS
- FreeBSD

and also runs tests on the first two.

The beta and nightly targets are only tested on Linux x64, as they were until now. All other OSes use stable Rust.

The commit also changed the `cache` option to `cache: cargo`, since that is the setting [recommended by Travis](https://docs.travis-ci.com/user/caching/#Rust-Cargo-cache) for Rust projects. It should do the same as the previous setting, and additionally cache the Cargo installation folder.

Also added the `dist: trusty` setting, to use the new [`trusty` images on Travis](https://docs.travis-ci.com/user/trusty-ci-environment/). They are faster, because they are container based.