### PR TITLE
Fix wrong number of CPUs on Android targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["cpu", "cpus", "cores"]
 categories = ["hardware-support"]
 
 [dependencies]
-libc = "^0.2.26"
+libc = "0.2.26"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["cpu", "cpus", "cores"]
 categories = ["hardware-support"]
 
 [dependencies]
-libc = "0.2.6"
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["cpu", "cpus", "cores"]
 categories = ["hardware-support"]
 
 [dependencies]
-libc = "0.2"
+libc = "^0.2.26"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,9 +301,9 @@ fn get_num_cpus() -> usize {
     // On ARM targets, processors could be turned off to save power.
     // Use `_SC_NPROCESSORS_CONF` to get the real number.
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
-    const CONF_NAME: libc::c_int = _SC_NPROCESSORS_CONF;
+    const CONF_NAME: libc::c_int = libc::_SC_NPROCESSORS_CONF;
     #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-    const CONF_NAME: libc::c_int = _SC_NPROCESSORS_ONLN;
+    const CONF_NAME: libc::c_int = libc::_SC_NPROCESSORS_ONLN;
 
     let cpus = unsafe { libc::sysconf(CONF_NAME) };
     if cpus < 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ fn get_num_cpus() -> usize {
     target_os = "fuchsia")
 )]
 fn get_num_cpus() -> usize {
-    let cpus = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+    let cpus = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_CONF) };
     if cpus < 1 {
         1
     } else {


### PR DESCRIPTION
I had a pull request to fix #34. Unfortunately that broke Android builds. I've since submitted a pull request to `libc`, and it's now accepted and released.

This pull request changes `Cargo.toml` to use `libc` to version `0.2.26` or newer.

Fixes #34.

Also, issue #8 asks for Android support, and I think `num_cpus` had it for a while. It can be closed too.