### PR TITLE
Add test for Travis CPU counts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,13 @@ script:
   # Only run the targets if we are on the same OS.
   - if [ "$RUN" == "1" ]; then cargo test --verbose --target "$TARGET"; fi
 
+env:
+  global:
+    # Per https://docs.travis-ci.com/user/reference/overview/ -
+    # Travis CI servers make 2 cores available to processes via
+    # virtualization.
+    - EXPECTED_TRAVIS_CPU_COUNT=2
+
 matrix:
   include:
     # Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@ script:
 
 env:
   global:
-    # Per https://docs.travis-ci.com/user/reference/overview/ -
-    # Travis CI servers make 2 cores available to processes via
-    # virtualization.
-    - EXPECTED_TRAVIS_CPU_COUNT=2
+    # Travis CI servers make 2 cores available to processes via virtualization.
+    # See https://docs.travis-ci.com/user/reference/overview/
+    - NUM_CPUS_TEST_GET=2
 
 matrix:
   include:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,11 +345,4 @@ mod tests {
             assert!(num < 236_451);
         }
     }
-
-    #[test]
-    fn test_travis_cpu_count() {
-        if let Some(expected_cpus) = env_var("EXPECTED_TRAVIS_CPU_COUNT") {
-            assert_eq!(super::get(), expected_cpus);
-        }
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,4 +359,16 @@ mod tests {
             assert!(physical <= logical);
         }
     }
+
+    #[test]
+    fn test_travis_cpu_count() {
+        if let Ok(_) = ::std::env::var("TRAVIS") {
+            // Per https://docs.travis-ci.com/user/reference/overview/ -
+            // Travis CI servers make 2 cores available to processes via
+            // virtualization.
+            let expected_cpus = 2;
+
+            assert_eq!(super::get(), expected_cpus);
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,6 +351,12 @@ mod tests {
         let logical = super::get();
         let physical = super::get_physical();
         println!("physical: {:?}, logical: {:?}", physical, logical);
-        assert!(physical <= logical);
+        if let Ok(_) = ::std::env::var("TRAVIS") {
+            // Travis CI uses virtualization.
+            // It's normal (and correct) to see 16 physical and 2 logical.
+            assert!(physical >= logical);
+        } else {
+            assert!(physical <= logical);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,12 +362,7 @@ mod tests {
 
     #[test]
     fn test_travis_cpu_count() {
-        if let Ok(_) = ::std::env::var("TRAVIS") {
-            // Per https://docs.travis-ci.com/user/reference/overview/ -
-            // Travis CI servers make 2 cores available to processes via
-            // virtualization.
-            let expected_cpus = 2;
-
+        if let Some(expected_cpus) = env_var("EXPECTED_TRAVIS_CPU_COUNT") {
             assert_eq!(super::get(), expected_cpus);
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,20 +347,6 @@ mod tests {
     }
 
     #[test]
-    fn test_physical_less_logical() {
-        let logical = super::get();
-        let physical = super::get_physical();
-        println!("physical: {:?}, logical: {:?}", physical, logical);
-        if let Ok(_) = ::std::env::var("EXPECTED_TRAVIS_CPU_COUNT") {
-            // Travis CI uses virtualization.
-            // It's normal (and correct) to see 16 physical and 2 logical.
-            assert!(physical >= logical);
-        } else {
-            assert!(physical <= logical);
-        }
-    }
-
-    #[test]
     fn test_travis_cpu_count() {
         if let Some(expected_cpus) = env_var("EXPECTED_TRAVIS_CPU_COUNT") {
             assert_eq!(super::get(), expected_cpus);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ mod tests {
         let logical = super::get();
         let physical = super::get_physical();
         println!("physical: {:?}, logical: {:?}", physical, logical);
-        if let Ok(_) = ::std::env::var("TRAVIS") {
+        if let Ok(_) = ::std::env::var("EXPECTED_TRAVIS_CPU_COUNT") {
             // Travis CI uses virtualization.
             // It's normal (and correct) to see 16 physical and 2 logical.
             assert!(physical >= logical);


### PR DESCRIPTION
Travis CI [virtualizes its 16 physical CPUs to 2 per instance](https://docs.travis-ci.com/user/reference/overview/).

This PR:

* Fixes `test_physical_less_logical` by reversing the comparison (`logical >= physical` becomes `logical <= physical`) when the `TRAVIS` env var is present, which [it will be on Travis instances](https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables). This reflects the reality that Travis's virtualization means there genuinely are fewer logical cores (2) than physical (16). Tests still pass locally and on AppVeyor because of the env var check.
* Adds a test that the number of logical cores is exactly 2 when the `TRAVIS` env var is present. I added this to prevent potential future regressions. In other systems (specifically Haskell) I've seen bugs where CPU counts are misreported in virtualization environments, leading to horrendous performance problems like a program forking 32 processes because it thinks there are 32 cores available to parallelize them, when in fact only 2 cores are available. These problems have been hard to detect in the wild, and I think it's worthwhile to have the peace of mind of an explicit canary test verifying that this produces the expected CPU count on Travis.

~~**Note:** when I [ran this branch on Travis](https://travis-ci.org/rtfeldman/num_cpus/builds/276036922), all the `Rust:stable` and `Rust:nightly` branches passed. However, `Rust:beta` failed, with `logical` being misreported as 32 (essentially ignoring the virtualization - the same issue I've encountered with Haskell) instead of the correct value of `2`, which both `stable` and `nightly` reported. I have no explanation for why this happened on `beta` but not on `nightly` or `stable`.~~ **EDIT:** re-ran it on https://travis-ci.org/rtfeldman/num_cpus/builds/276045419 after rebasing the branch, and could not reproduce. Never mind - seems to be good!