### PR TITLE
Change `fallback` to `fall back`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub fn get_physical() -> usize {
 #[cfg(not(any(target_os = "linux", target_os = "windows", target_os="macos")))]
 #[inline]
 fn get_num_physical_cpus() -> usize {
-    // Not implemented, fallback
+    // Not implemented, fall back
     get_num_cpus()
 }
 


### PR DESCRIPTION
Changes the spelling of "fallback" to "fall back".

Fixes #54.