### PR TITLE
added dummy wasm-unknown-unknown backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,6 +379,11 @@ fn get_num_cpus() -> usize {
     1
 }
 
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+fn get_num_cpus() -> usize {
+    1
+}
+
 #[cfg(test)]
 mod tests {
     fn env_var(name: &'static str) -> Option<usize> {


### PR DESCRIPTION
This adds the *wasm-unknown-unknown* backend similar to the already present *wasm-unknown-emscripten*, i.e. a dummy function that just returns 1 as the number of CPUs. I thought it better to have a separate function for it, i.e. distinct from the emscripten one, but feel free to coalesce the two if needed be. I have prepared a test repo for it: [oldmammuth/test-num_cpus](https://github.com/oldmammuth/test-num_cpus).