### PR TITLE
Add a flag to allow compilation on nintendo 3ds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,7 @@ fn get_num_cpus() -> usize {
     }
 }
 
-#[cfg(any(target_os = "emscripten", target_os = "redox", target_os = "haiku"))]
+#[cfg(any(target_os = "emscripten", target_os = "redox", target_os = "haiku", target_os = "horizon"))]
 fn get_num_cpus() -> usize {
     1
 }


### PR DESCRIPTION
As several crates depend on num_cpu and cannot get compiled on nintendo 3ds due to its absence of 3ds compatible get_num_cpus function the target_os = "horizon" flag has been added to the get_num_cpu function returning 1.

The old 3ds has 2 cores but the 1st one seems to be dedicated to the system which leaves 1 for user applications, however the new 3ds has 4 cpus (still 1 dedicated to the system), leaving 3 cores for user applications. 

Maybe @FenrirWolf @HybridEidolon or @panicbit have a clue on how to handle this situation?