### PR TITLE
Add support for x86_64-fortanix-unknown-sgx target 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,7 +378,7 @@ fn get_num_cpus() -> usize {
     target_os = "emscripten",
     target_os = "redox",
     target_os = "haiku",
-    all(target_arch = "wasm32", not(target_os = "emscripten")),
+    target_arch = "wasm32",
     target_env = "sgx"
 ))]
 fn get_num_cpus() -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,12 +374,13 @@ fn get_num_cpus() -> usize {
     }
 }
 
-#[cfg(any(target_os = "emscripten", target_os = "redox", target_os = "haiku"))]
-fn get_num_cpus() -> usize {
-    1
-}
-
-#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+#[cfg(any(
+    target_os = "emscripten",
+    target_os = "redox",
+    target_os = "haiku",
+    all(target_arch = "wasm32", not(target_os = "emscripten")),
+    target_env = "sgx"
+))]
 fn get_num_cpus() -> usize {
     1
 }


### PR DESCRIPTION
The x86_64-fortanix-unknown-sgx recently gained Tier 3 support upstream.