### PR TITLE
Automatically check if README.md examples are working when running "cargo test"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ readme = "README.md"
 
 [dependencies]
 libc = "0.2.26"
+
+[dev-dependencies]
+doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,12 @@
 #[cfg(not(windows))]
 extern crate libc;
 
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 /// Returns the number of available CPUs of the current system.
 /// 


### PR DESCRIPTION
Since rustdoc nightly now provides "cfg(test)" when running on test mode, we can now use this macro on test mode only to check if README.md examples are working as expected.