### PR TITLE
Remove bitrig support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,6 @@ fn get_num_cpus() -> usize {
 
 #[cfg(any(target_os = "freebsd",
           target_os = "dragonfly",
-          target_os = "bitrig",
           target_os = "netbsd"))]
 fn get_num_cpus() -> usize {
     let mut cpus: libc::c_uint = 0;
@@ -444,7 +443,6 @@ fn get_num_cpus() -> usize {
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "dragonfly",
-    target_os = "bitrig",
     target_os = "netbsd",
     target_os = "haiku",
     windows,


### PR DESCRIPTION
Bitrig is now defunct and rustc has already removed its support.