### PR TITLE
Use MaybeUninit::{uninit|zeroed} instead of mem::{uninitialized|zeroed}

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,9 +338,11 @@ fn get_num_physical_cpus() -> usize {
 fn get_num_cpus() -> usize {
     let mut set: std::mem::MaybeUninit<libc::cpu_set_t> = std::mem::MaybeUninit::zeroed();
     if unsafe { libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), set.as_mut_ptr()) } == 0 {
+        // We should have an initted `set` because of the call to `sched_getaffinity`.
+        let set: libc::cpu_set_t = unsafe { set.assume_init() };
         let mut count: u32 = 0;
         for i in 0..libc::CPU_SETSIZE as usize {
-            if unsafe { libc::CPU_ISSET(i, &*(set.as_ptr())) } {
+            if unsafe { libc::CPU_ISSET(i, &set) } {
                 count += 1
             }
         }


### PR DESCRIPTION
Replaces `mem::uninitialized()` with `MaybeUninit::unit()`, and `mem::zeroed()` with `MaybeUninit::zeroed()`.
The motivation is that `mem::uninitialized()` will be deprecated in 1.39 (see https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes) , and that `MaybeUninit` is more safe to use.

The tests still pass on Windows, and WSL. I dont have a `haiku` setup, so I couldn't test the made changes for that OS.