### PR TITLE
Replace `mem::uninitialized()` with `mem::zeroed()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ fn get_num_cpus() -> usize {
     }
 
     unsafe {
-        let mut sysinfo: SYSTEM_INFO = std::mem::uninitialized();
+        let mut sysinfo: SYSTEM_INFO = std::mem::zeroed();
         GetSystemInfo(&mut sysinfo);
         sysinfo.dwNumberOfProcessors as usize
     }
@@ -422,7 +422,7 @@ fn get_num_cpus() -> usize {
         fn get_system_info(info: *mut system_info) -> status_t;
     }
 
-    let mut info: system_info = unsafe { mem::uninitialized() };
+    let mut info: system_info = unsafe { mem::zeroed() };
     let status = unsafe { get_system_info(&mut info as *mut _) };
     if status == 0 {
         info.cpu_count as usize


### PR DESCRIPTION
It *probably* doesn't matter.  But really it can only help.  It's theoretically a performance malus but it's so tiny to be irrelevant; I have yet to need a program to find out how many CPU's it has more than once.

Safety: all the uses of `zeroed()` are for C structs that contain integers, raw pointers or `c_char` only, so it's always valid.

Edit: Hah, I didn't see #82.  Either one is good!