### PR TITLE
add support of the unikernel RustyHermit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ readme = "README.md"
 [dependencies]
 libc = "0.2.26"
 
+[target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
+hermit-abi = "0.1.3"
+
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@
 #[cfg(not(windows))]
 extern crate libc;
 
+#[cfg(target_os = "hermit")]
+extern crate hermit_abi;
+
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
@@ -436,6 +439,11 @@ fn get_num_cpus() -> usize {
     }
 }
 
+#[cfg(target_os = "hermit")]
+fn get_num_cpus() -> usize {
+    unsafe { hermit_abi::get_processor_count() }
+}
+
 #[cfg(not(any(
     target_os = "nacl",
     target_os = "macos",
@@ -450,6 +458,7 @@ fn get_num_cpus() -> usize {
     target_os = "dragonfly",
     target_os = "netbsd",
     target_os = "haiku",
+    target_os = "hermit",
     windows,
 )))]
 fn get_num_cpus() -> usize {


### PR DESCRIPTION
We are developing the unikernel RustyHermit (https://github.com/hermitcore/libhermit-rs), where the kernel is written in Rust and is already part of the Rust Standard Library. With this pull request, we want to integrate our interface to determine the number of CPUs.