### PR TITLE
Add wasm support via navigator.hardware_concurrency()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,15 @@ libc = "0.2.26"
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
 hermit-abi = "0.1.3"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { version = "~0.2", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "~0.3"
+features = [
+    "Navigator",
+    "Window"
+]
+
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@ extern crate libc;
 #[cfg(target_os = "hermit")]
 extern crate hermit_abi;
 
+#[cfg(target_arch = "wasm32")]
+extern crate web_sys;
+
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
@@ -451,6 +454,17 @@ fn get_num_cpus() -> usize {
     unsafe { hermit_abi::get_processor_count() }
 }
 
+#[cfg(target_arch = "wasm32")]
+fn get_num_cpus() -> usize {
+    let window = web_sys::window().expect("No global `window` exists");
+    let cpus: f64 = window.navigator().hardware_concurrency();
+    if cpus < 1.0 {
+        1
+    } else {
+        cpus as usize
+    }
+}
+
 #[cfg(not(any(
     target_os = "nacl",
     target_os = "macos",
@@ -466,6 +480,7 @@ fn get_num_cpus() -> usize {
     target_os = "netbsd",
     target_os = "haiku",
     target_os = "hermit",
+    target_arch = "wasm32",
     windows,
 )))]
 fn get_num_cpus() -> usize {


### PR DESCRIPTION
Currently, `num_cpus::get()` always returns 1 on web assembly targets. 

Although wasm is typically limited to single-threaded execution itself, it is possible to make use of multiple CPUs via [Web Workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)

On the `wasm32-unknown-unknown` platform, using the wasm_bindgen and web_sys crates, we can get a more accurate result by using `navigator.hardware_concurrency()` to get the number of CPUs on a system.

I tried to keep the code as similar as possible to the existing library.

Reference: 
[1] https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
[2] https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Navigator.html#method.hardware_concurrency


## Testing

I created a very basic test based on the [wasm-bindgen Hello World](https://rustwasm.github.io/docs/wasm-bindgen/examples/dom.html)
The `Cargo.toml` is the same as [upstream](https://github.com/rustwasm/wasm-bindgen/blob/master/examples/dom/Cargo.toml), but also has the 'Navigator' feature enabled for web-sys

lib.rs:
```rust
use wasm_bindgen::prelude::*;

// Called by our JS entry point to run the example
#[wasm_bindgen(start)]
pub fn run() -> Result<(), JsValue> {
    // Use `web_sys`'s global `window` function to get a handle on the global
    // window object.
    let window = web_sys::window().expect("no global `window` exists");
    let document = window.document().expect("should have a document on window");
    let body = document.body().expect("document should have a body");

    // Manufacture the element we're gonna append
    let val = document.create_element("p")?;

    val.set_inner_html(&format!("num_cpus::get() = {}", num_cpus::get()));
    body.append_child(&val)?;

    let navigator = window.navigator();
    let logical_cpus = navigator.hardware_concurrency();

    let val2 = document.create_element("p")?;
    val2.set_inner_html(&format!("navigator.hardware_concurrency() = {}", logical_cpus));
    body.append_child(&val2)?;

    Ok(())
}
```

I build the test crate for wasm without a bundler as follows:
```
wasm-pack build --target web
```

I also have a basic index.html page that I copy into the `pkg` directory that wasm-pack creates:

```html
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <title>WASM num_cpu Test</title>
  </head>
  <body>
  <script type="module">
      import init from './wasm_example_num_cpus.js';
      async function run() {
        await init();
      }
      run();
    </script>
  </body>
</html>
```

I then start an http server in the `pkg` directory and browse to it. 
```
basic-http-server -a '127.0.0.1:4000' ./pkg
```

Previously, `num_cpus::get()` would return 1, but now it correctly returns 8 on my system.

This is my first Rust contribution so please let me know if I should change anything. 