### PR TITLE
get rid of deprecated mem::uninitialized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ fn get_num_cpus() -> usize {
     }
 
     unsafe {
-        let mut sysinfo: SYSTEM_INFO = std::mem::uninitialized();
+        let mut sysinfo: SYSTEM_INFO = std::mem::zeroed(); // all involved types permit zero-initialization
         GetSystemInfo(&mut sysinfo);
         sysinfo.dwNumberOfProcessors as usize
     }
@@ -437,7 +437,7 @@ fn get_num_cpus() -> usize {
         fn get_system_info(info: *mut system_info) -> status_t;
     }
 
-    let mut info: system_info = unsafe { mem::uninitialized() };
+    let mut info: system_info = unsafe { mem::zeroed() }; // all involved types permit zero-initialization
     let status = unsafe { get_system_info(&mut info as *mut _) };
     if status == 0 {
         info.cpu_count as usize


### PR DESCRIPTION
`mem::uninitialized()` is deprecated and should not be used any more. Under [current conservative rules](https://doc.rust-lang.org/reference/behavior-considered-undefined.html), creating uninitialized integers (like e.g. the Windows code does here) is UB. Miri recently started checking this for raw pointers, which leads to failures for this crate.

This ports the code to `MaybeUninit`, a safer and also UB-free alternative. However, this raises the minimal Rust version to 1.36. If that is a problem, we could instead use https://crates.io/crates/maybe-uninit which works with Rust 1.20+ (it is not technically correct for Rust versions older than 1.36, but at least it compiles -- and it is no worse than what this crate currently does).