### PR TITLE
Cull unused libc dependency on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["cpu", "cpus", "cores"]
 categories = ["hardware-support"]
 readme = "README.md"
 
-[dependencies]
+[target.'cfg(not(windows))'.dependencies]
 libc = "0.2.26"
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]


### PR DESCRIPTION
libc is already not used on windows, no need to download & compile it:

https://github.com/seanmonstar/num_cpus/blob/9b146faf097c6e2b0bb0a313d0a978e537eeb0fd/src/lib.rs#L34-L35

(**EDIT:** looks like this shaves a good 15 seconds off each appveyor build? [182](https://ci.appveyor.com/project/seanmonstar/num-cpus/builds/33789451) vs [185](https://ci.appveyor.com/project/seanmonstar/num-cpus/builds/35087680))