### PR TITLE
README.md: Mention `available_parallelism`; explain when to still use `num_cpus`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ extern crate num_cpus;
 // count logical cores this process could try to use
 let num = num_cpus::get();
 ```
+
+## Rust version support
+
+`num_cpus` supports Rust 1.13 and newer.
+
+If your project can require Rust 1.59 or newer, similar support exists in the
+Rust standard library, via the
+[`std::thread::available_parallelism`](https://doc.rust-lang.org/std/thread/fn.available_parallelism.html)
+function. `num_cpus` provides the same functionality for projects that need to
+support older versions of Rust.


### PR DESCRIPTION
With `std::thread::available_parallelism` stabilized in 1.59, some
projects may want to switch to it. Document the key difference (minimum
Rust version support) to help projects make that decision more
carefully.
