### PR TITLE
do not attempt to open files in Miri

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -126,6 +126,11 @@ fn init_cgroups() {
     // Should only be called once
     debug_assert!(CGROUPS_CPUS.load(Ordering::SeqCst) == 0);
 
+    // Fails in Miri by default (cannot open files), and Miri does not have parallelism anyway.
+    if cfg!(miri) {
+        return;
+    }
+
     if let Some(quota) = load_cgroups("/proc/self/cgroup", "/proc/self/mountinfo") {
         if quota == 0 {
             return;


### PR DESCRIPTION
Using this from Miri leads to the following error:
```
error: unsupported operation: `open` not available when isolation is enabled
   --> /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sys/unix/fs.rs:887:36
    |
887 |         let fd = cvt_r(|| unsafe { open64(path.as_ptr(), flags, opts.mode as c_int) })?;
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `open` not available when isolation is enabled
    |
    = help: pass the flag `-Zmiri-disable-isolation` to disable isolation;
    = help: or pass `-Zmiri-isolation-error=warn` to configure Miri to return an error code from isolated operations (if supported for that operation) and continue with a warning
            
    = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sys/unix/fs.rs:887:36
    = note: inside `std::sys::unix::cvt_r::<i32, [closure@std::sys::unix::fs::File::open_c::{closure#0}]>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sys/unix/mod.rs:244:19
    = note: inside `std::sys::unix::fs::File::open_c` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sys/unix/fs.rs:887:18
    = note: inside `std::sys::unix::fs::File::open` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sys/unix/fs.rs:875:9
    = note: inside `std::fs::OpenOptions::_open` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/fs.rs:968:9
    = note: inside `std::fs::OpenOptions::open::<&std::path::Path>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/fs.rs:964:9
    = note: inside `std::fs::File::open::<&str>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/fs.rs:344:9
    = note: inside `num_cpus::linux::Subsys::load_cpu::<&str>` at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/num_cpus-1.13.1/src/linux.rs:271:26
    = note: inside `num_cpus::linux::load_cgroups::<&str, &str>` at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/num_cpus-1.13.1/src/linux.rs:146:24
    = note: inside `num_cpus::linux::init_cgroups` at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/num_cpus-1.13.1/src/linux.rs:129:26
    = note: inside `<fn() {num_cpus::linux::init_cgroups} as std::ops::FnOnce<()>>::call_once - shim(fn() {num_cpus::linux::init_cgroups})` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/core/src/ops/function.rs:248:5
    = note: inside closure at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sync/once.rs:276:41
    = note: inside `std::sync::Once::call_inner` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sync/once.rs:434:21
    = note: inside `std::sync::Once::call_once::<fn() {num_cpus::linux::init_cgroups}>` at /home/r/.rustup/toolchains/miri/lib/rustlib/src/rust/library/std/src/sync/once.rs:276:9
    = note: inside `num_cpus::linux::cgroups_num_cpus` at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/num_cpus-1.13.1/src/linux.rs:114:5
    = note: inside `num_cpus::linux::get_num_cpus` at /home/r/.cargo/registry/src/github.com-1ecc6299db9ec823/num_cpus-1.13.1/src/linux.rs:33:11
```
As the error indicates, we could use `-Zmiri-disable-isolation` or `-Zmiri-isolation-error=warn` to make things work, but given that Miri anyway has no parallelism, IMO it makes more sense to skip the file opening part entirely in Miri.