### PR TITLE
ci: update actions/checkout in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - x86_64-unknown-linux-gnu
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: |
         rustup default ${{ matrix.rust }}
@@ -55,7 +55,7 @@ jobs:
           - x86_64-unknown-linux-musl
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: |
         rustup default ${{ matrix.rust }}
@@ -75,7 +75,7 @@ jobs:
           - x86_64-apple-darwin
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: |
         rustup default ${{ matrix.rust }}
@@ -96,7 +96,7 @@ jobs:
           - x86_64-pc-windows-msvc
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run tests
       run: |
         rustup default ${{ matrix.rust }}
@@ -143,7 +143,7 @@ jobs:
           - aarch64-apple-ios-sim
           - aarch64-apple-darwin
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run build
       run: |
         rustup default ${{ matrix.rust }}
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test Cgroup
       run: |
         docker build -f ci/cgroups/Dockerfile -t num-cpus-cgroups .


### PR DESCRIPTION
Updates the `actions/checkout` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.