### PR TITLE
increase version number of hermit-abi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ readme = "README.md"
 libc = "0.2.26"
 
 [target.'cfg(all(any(target_arch = "x86_64", target_arch = "aarch64"), target_os = "hermit"))'.dependencies]
-hermit-abi = "0.2.6"
+hermit-abi = "0.3.0"


### PR DESCRIPTION
RustHermit publishes a new ABI, which isn't completely backward compatible. For `num_cpus` are these changes not important. However, I wrote a PR to update `num_cpus` to avoid that `std` includes all different ABI versions.

See also rust-lang/rust#107405