### PR TITLE
Minor changes to improve compilation speed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "num_cpus"
 version = "1.16.0"
+rust-version = "1.13"
 description = "Get the number of CPUs on a machine."
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -131,7 +131,7 @@ fn init_cgroups() {
         return;
     }
 
-    if let Some(quota) = load_cgroups("/proc/self/cgroup", "/proc/self/mountinfo") {
+    if let Some(quota) = load_cgroups("/proc/self/cgroup".as_ref(), "/proc/self/mountinfo".as_ref()) {
         if quota == 0 {
             return;
         }
@@ -143,11 +143,7 @@ fn init_cgroups() {
     }
 }
 
-fn load_cgroups<P1, P2>(cgroup_proc: P1, mountinfo_proc: P2) -> Option<usize>
-where
-    P1: AsRef<Path>,
-    P2: AsRef<Path>,
-{
+fn load_cgroups(cgroup_proc: &Path, mountinfo_proc: &Path) -> Option<usize> {
     let subsys = some!(Subsys::load_cpu(cgroup_proc));
     let mntinfo = some!(MountInfo::load_cpu(mountinfo_proc, subsys.version));
     let cgroup = some!(Cgroup::translate(mntinfo, subsys));
@@ -250,7 +246,7 @@ impl Cgroup {
 }
 
 impl MountInfo {
-    fn load_cpu<P: AsRef<Path>>(proc_path: P, version: CgroupVersion) -> Option<MountInfo> {
+    fn load_cpu(proc_path: &Path, version: CgroupVersion) -> Option<MountInfo> {
         let file = some!(File::open(proc_path).ok());
         let file = BufReader::new(file);
 
@@ -305,7 +301,7 @@ impl MountInfo {
 }
 
 impl Subsys {
-    fn load_cpu<P: AsRef<Path>>(proc_path: P) -> Option<Subsys> {
+    fn load_cpu(proc_path: &Path) -> Option<Subsys> {
         let file = some!(File::open(proc_path).ok());
         let file = BufReader::new(file);
 
@@ -369,7 +365,7 @@ mod tests {
             // test only one optional fields
             let path = join!(FIXTURES_PROC, "mountinfo");
 
-            let mnt_info = MountInfo::load_cpu(path, CgroupVersion::V1).unwrap();
+            let mnt_info = MountInfo::load_cpu(&path, CgroupVersion::V1).unwrap();
 
             assert_eq!(mnt_info.root, "/");
             assert_eq!(mnt_info.mount_point, "/sys/fs/cgroup/cpu,cpuacct");
@@ -377,7 +373,7 @@ mod tests {
             // test zero optional field
             let path = join!(FIXTURES_PROC, "mountinfo_zero_opt");
 
-            let mnt_info = MountInfo::load_cpu(path, CgroupVersion::V1).unwrap();
+            let mnt_info = MountInfo::load_cpu(&path, CgroupVersion::V1).unwrap();
 
             assert_eq!(mnt_info.root, "/");
             assert_eq!(mnt_info.mount_point, "/sys/fs/cgroup/cpu,cpuacct");
@@ -385,7 +381,7 @@ mod tests {
             // test multi optional fields
             let path = join!(FIXTURES_PROC, "mountinfo_multi_opt");
 
-            let mnt_info = MountInfo::load_cpu(path, CgroupVersion::V1).unwrap();
+            let mnt_info = MountInfo::load_cpu(&path, CgroupVersion::V1).unwrap();
 
             assert_eq!(mnt_info.root, "/");
             assert_eq!(mnt_info.mount_point, "/sys/fs/cgroup/cpu,cpuacct");
@@ -395,7 +391,7 @@ mod tests {
         fn test_load_subsys() {
             let path = join!(FIXTURES_PROC, "cgroup");
 
-            let subsys = Subsys::load_cpu(path).unwrap();
+            let subsys = Subsys::load_cpu(&path).unwrap();
 
             assert_eq!(subsys.base, "/");
             assert_eq!(subsys.version, CgroupVersion::V1);
@@ -494,7 +490,7 @@ mod tests {
             // test only one optional fields
             let path = join!(FIXTURES_PROC, "mountinfo");
 
-            let mnt_info = MountInfo::load_cpu(path, CgroupVersion::V2).unwrap();
+            let mnt_info = MountInfo::load_cpu(&path, CgroupVersion::V2).unwrap();
 
             assert_eq!(mnt_info.root, "/");
             assert_eq!(mnt_info.mount_point, "/sys/fs/cgroup");
@@ -504,7 +500,7 @@ mod tests {
         fn test_load_subsys() {
             let path = join!(FIXTURES_PROC, "cgroup");
 
-            let subsys = Subsys::load_cpu(path).unwrap();
+            let subsys = Subsys::load_cpu(&path).unwrap();
 
             assert_eq!(subsys.base, "/");
             assert_eq!(subsys.version, CgroupVersion::V2);
@@ -514,7 +510,7 @@ mod tests {
         fn test_load_subsys_multi() {
             let path = join!(FIXTURES_PROC, "cgroup_multi");
 
-            let subsys = Subsys::load_cpu(path).unwrap();
+            let subsys = Subsys::load_cpu(&path).unwrap();
 
             assert_eq!(subsys.base, "/");
             assert_eq!(subsys.version, CgroupVersion::V1);

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read};
 use std::mem;
@@ -62,7 +61,7 @@ pub fn get_num_physical_cpus() -> usize {
         Err(_) => return get_num_cpus(),
     };
     let reader = BufReader::new(file);
-    let mut map = HashMap::new();
+    let mut core_list = Vec::new();
     let mut physid: u32 = 0;
     let mut cores: usize = 0;
     let mut chgcount = 0;
@@ -93,11 +92,20 @@ pub fn get_num_physical_cpus() -> usize {
         }
 
         if chgcount == 2 {
-            map.insert(physid, cores);
+            core_list.push((physid, cores));
             chgcount = 0;
         }
     }
-    let count = map.iter().map(|(_, cores)| *cores).sum();
+
+    core_list.sort_by_key(|&(id, _)| id);
+
+    let mut count = 0;
+    let mut prev = None;
+    for (id, cores) in core_list {
+        if prev == Some(id) { continue }
+        prev = Some(id);
+        count += cores;
+    }
 
     if count == 0 {
         get_num_cpus()

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -9,13 +9,13 @@ use std::sync::Once;
 use libc;
 
 macro_rules! debug {
-    ($($args:expr),*) => ({
-        if false {
-        //if true {
-            println!($($args),*);
-        }
-    });
+    ($($args:tt)*) => ({});
 }
+// macro_rules! debug {
+//     ($($args:expr),*) => ({
+//         println!($($args),*);
+//     });
+// }
 
 macro_rules! some {
     ($e:expr) => {{


### PR DESCRIPTION
This crate is small and compiles quickly, but it's also used *everywhere*, so trying to improve the compilation speed is worth it.

This PR has a number of optimizations; each commit is independent, so feel free to cherry-pick and take whichever changes you want.  This PR preserves the current MSRV of 1.13.

Changes:
- Add `rust-version = "1.13"` to the `Cargo.toml`, to partially document the current MSRV
- Change internal methods that use `AsRef<Path>` to just take `&Path`
- Use loops instead of iterator combinators in parsing functions
- Make the `debug!` macro generate no code when not in use
- Use a `Vec` instead of a `HashMap` when counting physical cores; using the `HashMap` requires compiling a lot more code.  (The `Vec` should also be faster.)

My non-scientific benchmarks of a clean build of the library (`libc` + `num_cpus`)
- in release mode: 0.8s -> 0.7s (-13%)
- in debug mode: 0.63s -> 0.60s (-5%)

Measuring the amount of code passed to LLVM, using [cargo-llvm-lines](https://github.com/dtolnay/cargo-llvm-lines):  
`cargo llvm-lines --lib -p num_cpus` (with `--release` for release builds)
- in release mode: 16325 -> 13039 (-20%)
- in debug mode: 24263 -> 18781 (-22%)
