### PR TITLE
Support for wasm-bindgen based querying of hardwareConcurrency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ libc = "0.2.26"
 
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = "0.3.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { version = "0.3.0", features = [
+    "WorkerNavigator",
+    "DedicatedWorkerGlobalScope",
+], optional = true }
+
+[features]
+wasm-bindgen-support = ["web-sys"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,22 @@ fn get_num_cpus() -> usize {
     unsafe { hermit_abi::get_processor_count() }
 }
 
+#[cfg(feature = "wasm-bindgen-support")]
+extern crate web_sys;
+
+#[cfg(feature = "wasm-bindgen-support")]
+fn get_num_cpus() -> usize {
+    use web_sys::{wasm_bindgen::JsCast, DedicatedWorkerGlobalScope};
+
+    let global = web_sys::js_sys::global();
+
+    // DedicatedWorkerGlobalScope is not always the correct type
+    // but the underlying global will always have access to `navigator`
+    // either way and this was the simplest way to work with `web_sys`.
+    let global = global.unchecked_into::<DedicatedWorkerGlobalScope>();
+    global.navigator().hardware_concurrency() as usize
+}
+
 #[cfg(not(any(
     target_os = "nacl",
     target_os = "macos",
@@ -449,6 +465,7 @@ fn get_num_cpus() -> usize {
     target_os = "netbsd",
     target_os = "haiku",
     target_os = "hermit",
+    feature = "wasm-bindgen-support",
     windows,
 )))]
 fn get_num_cpus() -> usize {


### PR DESCRIPTION
It is possible to multithread Rust in the browser by making use of Web Workers and `SharedArrayBuffer`.

This change adds an optional feature that can be opted into find the number of logical processors via the browsers `hardwareConcurrency` property: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/hardwareConcurrency

The change is careful to work both when called from the browser's main thread and when called from a Web Worker.